### PR TITLE
Better bubble up errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "fancy-regex",
  "instant",
  "nom",
+ "once_cell",
  "serde",
  "serde-wasm-bindgen",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "4.5.45", features = ["derive"] }
 thiserror = "2.0.15"
 fancy-regex = "0.16.1"
 instant = { version = "0.1.13", features = ["wasm-bindgen"] }
+once_cell = "1.21.3"
 
 # --- WASM-only deps (compiled only when target_arch = "wasm32") ---
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Previously:
```
> cargo run --release 'A;A=|7|'
    Finished `release` profile [optimized] target(s) in 0.12s
     Running `target\release\umiaq_cli.exe A;A=|7|`

thread 'main' panicked at src\constraints.rs:148:94:
called `Result::unwrap()` on an `Err` value: ParseFailure { s: "|7|" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\release\umiaq_cli.exe A;A=|7|` (exit code: 101)
```

Now:
```
> cargo run --release 'A;A=|7|'      
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `target\release\umiaq_cli.exe A;A=|7|`
Error: Form parsing failed: "|7|"
error: process didn't exit successfully: `target\release\umiaq_cli.exe A;A=|7|` (exit code: 1)
```

This also magically works in the web UI
<img width="795" height="610" alt="image" src="https://github.com/user-attachments/assets/3ce24ceb-79cc-4cd3-95bf-49fc8605c9a9" />

