### PR TITLE
Throw an exception in patterns.rs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,8 +16,13 @@ pub enum ParseError {
     EmptyForm,
     #[error("Invalid length range \"{input}\"")]
     InvalidLengthRange { input: String },
+    
     #[error("{str}")]
     InvalidComplexConstraint { str: String },
+    
+    #[error("Invalid input: {str}")]
+    InvalidInput { str: String },
+    
     #[error("int-parsing error: {0}")]
     ParseIntError(#[from] ParseIntError),
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -258,7 +258,7 @@ impl Patterns {
                         var_constraint.form = Some(f);
                     }
                 }
-            } else { // TODO? avoid swallowing error?
+            } else {
                 // We only want to add a form if it is parseable
                 // Specifically, things like |AB|=7 should not be picked up here
                 // TODO do we check for those separately?
@@ -267,7 +267,9 @@ impl Patterns {
                     self.p_list.push(Pattern::create(*form, next_form_ix));
                     next_form_ix += 1;
                 } else {
-                    // TODO throw exception
+                    return Err(Box::new(ParseError::InvalidInput {
+                        str: form.to_string(),
+                    }));
                 }
             }
         }


### PR DESCRIPTION
This PR depends on the other one (I think?)

Currently:
```
> cargo run --release 'A;???'                         
   Compiling umiaq v0.1.0 (C:\Users\boisv\RustroverProjects\umiaq-rust)
    Finished `release` profile [optimized] target(s) in 3.11s                                                                                      
     Running `target\release\umiaq_cli.exe A;???`
AAA
AAH
AAS
ABA
ABC
...
```

Now:
```
> cargo run --release 'A;???'
    Finished `release` profile [optimized] target(s) in 0.07s
     Running `target\release\umiaq_cli.exe A;???`
Error: Invalid input: ???
error: process didn't exit successfully: `target\release\umiaq_cli.exe A;???` (exit code: 1)
```
This also works in the web UI.