### PR TITLE
Better patterns.rs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,10 @@ pub enum ParseError {
     InvalidLengthRange { input: String },
     #[error("{str}")]
     InvalidComplexConstraint { str: String },
+
+    #[error("Invalid input: {str}")]
+    InvalidInput { str: String },
+    
     #[error("int-parsing error: {0}")]
     ParseIntError(#[from] ParseIntError),
 

--- a/src/joint_constraints.rs
+++ b/src/joint_constraints.rs
@@ -79,7 +79,18 @@ pub struct JointConstraint {
 impl FromStr for JointConstraint {
     type Err = ParseError;
 
+    /// Attempt to parse a `JointConstraint` from a string.
+    ///
+    /// This uses the existing `parse_joint_len` helper, which recognizes
+    /// joint length expressions such as `|AB|=7`.
+    ///
+    /// - On success, returns the parsed `JointConstraint`.
+    /// - On failure (`parse_joint_len` returns `None`), produces a
+    ///   `ParseError::InvalidInput` with the offending string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Delegate to the existing parser.
+        // `parse_joint_len` returns `Option<JointConstraint>`,
+        // so map `None` into a `ParseError`.
         parse_joint_len(s).ok_or_else(|| {
             ParseError::InvalidInput {
                 str: s.to_string(),
@@ -196,9 +207,17 @@ impl JointConstraints {
         JointConstraints { as_vec: jc_vec }
     }
 
+    /// Insert a new `JointConstraint` into this collection.
+    ///
+    /// This is a thin wrapper around `Vec::push` on the internal
+    /// storage. Keeping the push logic behind a method preserves
+    /// encapsulation: callers don’t need to know or rely on the fact
+    /// that `JointConstraints` is backed by a `Vec`
     pub(crate) fn add(&mut self, jc: JointConstraint) {
+        // Delegate to the underlying Vec implementation.
         self.as_vec.push(jc);
     }
+
 
     pub(crate) fn is_empty(&self) -> bool {
         self.as_vec.is_empty()

--- a/src/joint_constraints.rs
+++ b/src/joint_constraints.rs
@@ -76,6 +76,18 @@ pub struct JointConstraint {
     pub rel: RelMask,      // operator as data
 }
 
+impl FromStr for JointConstraint {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_joint_len(s).ok_or_else(|| {
+            ParseError::InvalidInput {
+                str: s.to_string(),
+            }
+        })
+    }
+}
+
 impl JointConstraint {
     /// Check satisfaction against current `bindings`.
     ///
@@ -182,6 +194,10 @@ impl JointConstraints {
         }).collect();
 
         JointConstraints { as_vec: jc_vec }
+    }
+
+    pub(crate) fn add(&mut self, jc: JointConstraint) {
+        self.as_vec.push(jc);
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -8,7 +8,7 @@ use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::LazyLock;
-use crate::joint_constraints::JointConstraint;
+use crate::joint_constraints::{JointConstraint, JointConstraints};
 
 /// The character that separates forms, in an equation
 pub const FORM_SEPARATOR: char = ';';
@@ -137,6 +137,20 @@ impl Pattern {
         }
     }
 
+    pub fn from_parsed(parsed: ParsedForm, raw: &str, original_index: usize) -> Self {
+        let deterministic = parsed.iter().all(|p| p.is_deterministic());
+        let vars = raw.chars().filter(char::is_variable).collect();
+
+        Self {
+            raw_string: raw.to_string(),
+            lookup_keys: HashSet::default(),
+            original_index,
+            is_deterministic: deterministic,
+            variables: vars,
+        }
+    }
+
+
     /// True iff every variable this pattern uses is included in its `lookup_keys`.
     pub(crate) fn all_vars_in_lookup_keys(&self) -> bool {
         self.variables.is_subset(&self.lookup_keys)
@@ -208,13 +222,14 @@ fn classify_form(form: &str) -> Result<FormKind, Box<ParseError>> {
 ///   with the variables seen so far (its *join key*).
 ///
 /// TODO change the name of this struct (since it contains (a list of) `Pattern`s... but also more)
-pub struct Patterns {
+pub struct EquationContext {
     /// List of patterns directly extracted from the input string (not constraints)
     // TODO should we keep Vec<Pattern> for each order or just one (likely ordered_list) and use map
     //      (original_to_ordered) when other is needed?
     pub p_list: Vec<Pattern>,
     /// Map of variable names (A-Z) to their associated constraints
     pub var_constraints: VarConstraints,
+    pub joint_constraints: JointConstraints,
     /// Reordered list of patterns, optimized for solving (most-constrained first)
     pub ordered_list: Vec<Pattern>,        // solver order
     /// ordered index -> original index
@@ -223,7 +238,7 @@ pub struct Patterns {
     pub original_to_ordered: Vec<usize>,
 }
 
-impl Patterns {
+impl EquationContext {
     fn build_order_maps(&mut self) {
         let n = self.p_list.len();
         self.ordered_to_original = self
@@ -247,71 +262,60 @@ impl Patterns {
     /// Non-constraint entries are added to `self.list` as actual patterns.
     fn set_var_constraints(&mut self, input: &str) -> Result<(), Box<ParseError>> {
         let forms: Vec<_> = input.split(FORM_SEPARATOR).collect();
-        // Iterate through all parts of the input string, split by `;`
-
-        let mut next_form_ix = 0; // counts only *forms* we accept
+        let mut next_form_ix = 0;
 
         for form in &forms {
-            if let Some(cap) = LEN_CMP_RE.captures(form).unwrap() {
-                let var_char = cap[1].chars().next().unwrap();
-                let op = ComparisonOperator::from_str(&cap[2])?; // TODO better error handling
-                let n = cap[3].parse::<usize>()?;
-                let vc = self.var_constraints.ensure(var_char);
-
-                match op {
-                    ComparisonOperator::EQ => vc.set_exact_len(n),
-                    ComparisonOperator::NE => {}
-                    ComparisonOperator::LE => vc.bounds.max_len_opt = Some(n),
-                    ComparisonOperator::GE => vc.bounds.min_len = n,
-                    ComparisonOperator::LT => vc.bounds.max_len_opt = n.checked_sub(1),   // n-1 (None if n==0)
-                    ComparisonOperator::GT => vc.bounds.min_len = n + 1, // TODO? check for overflow
-                }
-            } else if let Some(cap) = NEQ_RE.captures(form).unwrap() {
-                // Extract all variables from inequality constraint
-                // !=α (where α is a string of at least 2 distinct variables) means that any pair of
-                //     variables in α are not equal
-                // Examples:
-                // * !=AB means A != B
-                // * !=ABC means A != B, A != C, B != C
-                let vars: Vec<_> = cap[1].chars().collect();
-                for &var_char in &vars {
-                    let var_constraint = self.var_constraints.ensure(var_char);
-                    var_constraint.not_equal = vars.iter().copied().filter(|&x| x != var_char).collect();
-                }
-            } else if let Ok((var_char, cc_vc)) = get_complex_constraint(form) {
-                let var_constraint = self.var_constraints.ensure(var_char);
-
-                var_constraint.constrain_by(&cc_vc);
-
-                if let Some(f) = cc_vc.form {
-                    if let Some(old_form) = &var_constraint.form {
-                        if *old_form != f {
-                            return Err(Box::new(ParseError::ConflictingConstraint {
-                                var_char,
-                                older: old_form.clone(),
-                                newer: f,
-                            }));
-                        }
-                    } else {
-                        var_constraint.form = Some(f);
+            match classify_form(form)? {
+                FormKind::LenConstraint(var_char, op, n) => {
+                    let vc = self.var_constraints.ensure(var_char);
+                    match op {
+                        ComparisonOperator::EQ => vc.set_exact_len(n),
+                        ComparisonOperator::NE => {}
+                        ComparisonOperator::LE => vc.bounds.max_len_opt = Some(n),
+                        ComparisonOperator::GE => vc.bounds.min_len = n,
+                        ComparisonOperator::LT => vc.bounds.max_len_opt = n.checked_sub(1),
+                        ComparisonOperator::GT => vc.bounds.min_len = n.checked_add(1)
+                            .ok_or_else(|| Box::new(ParseError::InvalidInput {
+                                str: form.to_string(),
+                            }))?,
                     }
                 }
-            } else { // TODO? avoid swallowing error?
-                // We only want to add a form if it is parseable
-                // Specifically, things like |AB|=7 should not be picked up here
-                // TODO do we check for those separately?
-                // TODO avoid calling parse_form twice on the same form? (here and in solve_equation)
-                if let Ok(_parsed) = form.parse::<ParsedForm>() {
-                    self.p_list.push(Pattern::create(*form, next_form_ix));
+                FormKind::NeqConstraint(vars) => {
+                    for &var_char in &vars {
+                        let vc = self.var_constraints.ensure(var_char);
+                        vc.not_equal = vars.iter().copied().filter(|&x| x != var_char).collect();
+                    }
+                }
+                FormKind::ComplexConstraint(var_char, cc_vc) => {
+                    let vc = self.var_constraints.ensure(var_char);
+                    vc.constrain_by(&cc_vc);
+                    if let Some(f) = cc_vc.form {
+                        if let Some(old_form) = &vc.form {
+                            if *old_form != f {
+                                return Err(Box::new(ParseError::ConflictingConstraint {
+                                    var_char,
+                                    older: old_form.clone(),
+                                    newer: f,
+                                }));
+                            }
+                        } else {
+                            vc.form = Some(f);
+                        }
+                    }
+                }
+                FormKind::JointConstraint(jc) => {
+                    self.joint_constraints.add(jc);
+                }
+                FormKind::Pattern(parsed) => {
+                    self.p_list.push(Pattern::from_parsed(parsed, form, next_form_ix));
                     next_form_ix += 1;
-                } else {
-                    // TODO throw exception
                 }
             }
         }
 
         Ok(())
     }
+
 
     // TODO is this the right way to order things?
     /// Reorders the list of patterns to improve solving efficiency.
@@ -412,11 +416,11 @@ impl Patterns {
      */
 }
 
-impl FromStr for Patterns {
+impl FromStr for EquationContext {
     type Err = Box<ParseError>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut patterns = Patterns::default();
+        let mut patterns = EquationContext::default();
         patterns.set_var_constraints(s)?;
         patterns.ordered_list = patterns.ordered_patterns();
         patterns.build_order_maps();
@@ -481,7 +485,7 @@ fn get_complex_constraint(form: &str) -> Result<(char, VarConstraint), Box<Parse
 /// - If we implement `IntoIterator` for **`Patterns`**, iteration would *consume* (move) the
 ///   whole `Patterns`, which we don't want here.
 /// - Implementing it for **`&Patterns`** lets you iterate **by reference** without moving.
-impl<'a> IntoIterator for &'a Patterns {
+impl<'a> IntoIterator for &'a EquationContext {
     type Item = &'a Pattern;
     type IntoIter = std::slice::Iter<'a, Pattern>;
 
@@ -511,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_basic_pattern_and_constraints() {
-        let patterns = "AB;|A|=3;!=AB;B=(2:b*)".parse::<Patterns>().unwrap();
+        let patterns = "AB;|A|=3;!=AB;B=(2:b*)".parse::<EquationContext>().unwrap();
 
         // Test raw pattern list
         assert_eq!(vec!["AB".to_string()], patterns.p_list.iter().map(|p| p.raw_string.clone()).collect::<Vec<_>>());
@@ -539,7 +543,7 @@ mod tests {
 
     #[test]
     fn test_complex_re_len_only() {
-        let patterns = "A;A=(6)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(6)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of(6, 6),
@@ -551,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_complex_re_lit_only() {
-        let patterns = "A;A=(g*)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(g*)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of_unbounded(VarConstraint::DEFAULT_MIN),
@@ -562,7 +566,7 @@ mod tests {
     }
     #[test]
     fn test_complex_re() {
-        let patterns = "A;A=(3-4:x*)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(3-4:x*)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of(3, 4),
@@ -574,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_complex_re_unbounded_max_len() {
-        let patterns = "A;A=(3-:x*)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(3-:x*)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of_unbounded(3),
@@ -586,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_complex_re_unbounded_min_len() {
-        let patterns = "A;A=(-4:x*)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(-4:x*)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of(VarConstraint::DEFAULT_MIN, 4),
@@ -598,7 +602,7 @@ mod tests {
 
     #[test]
     fn test_complex_re_exact_len() {
-        let patterns = "A;A=(6:x*)".parse::<Patterns>().unwrap();
+        let patterns = "A;A=(6:x*)".parse::<EquationContext>().unwrap();
 
         let expected = VarConstraint {
             bounds: Bounds::of(6, 6),
@@ -612,7 +616,7 @@ mod tests {
     /// Test that ordering leaves the list unchanged when no reordering is needed.
     fn test_ordered_patterns() {
         let input = "ABC;BC;C";
-        let patterns = input.parse::<Patterns>().unwrap();
+        let patterns = input.parse::<EquationContext>().unwrap();
 
         let actual: Vec<_> = patterns
             .ordered_list
@@ -637,7 +641,7 @@ mod tests {
 
     #[test]
     fn test_len_gt() {
-        let patterns = "|A|>4;A".parse::<Patterns>().unwrap();
+        let patterns = "|A|>4;A".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         assert_eq!(a.bounds.min_len, 5);
         assert_eq!(a.bounds.max_len_opt, None);
@@ -645,7 +649,7 @@ mod tests {
 
     #[test]
     fn test_len_ge() {
-        let patterns = "|A|>=4;A".parse::<Patterns>().unwrap();
+        let patterns = "|A|>=4;A".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         assert_eq!(a.bounds.min_len, 4);
         assert_eq!(a.bounds.max_len_opt, None);
@@ -653,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_len_lt() {
-        let patterns = "|A|<4;A".parse::<Patterns>().unwrap();
+        let patterns = "|A|<4;A".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         // For <4, max becomes 3; <1 would become None via checked_sub
         assert_eq!(a.bounds.min_len, VarConstraint::DEFAULT_MIN);
@@ -662,7 +666,7 @@ mod tests {
 
     #[test]
     fn test_len_le() {
-        let patterns = "|A|<=4;A".parse::<Patterns>().unwrap();
+        let patterns = "|A|<=4;A".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         assert_eq!(a.bounds.min_len, VarConstraint::DEFAULT_MIN);
         assert_eq!(a.bounds.max_len_opt, Some(4));
@@ -671,7 +675,7 @@ mod tests {
     #[test]
     fn test_len_equality_then_complex_form_only() {
         // Equality first, then a complex constraint that only specifies a form
-        let patterns = "A;|A|=7;A=(x*a)".parse::<Patterns>().unwrap();
+        let patterns = "A;|A|=7;A=(x*a)".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap().clone();
 
         let expected = VarConstraint {
@@ -770,7 +774,7 @@ mod tests {
     /// Verify merging of min/max constraints with a literal form.
     fn test_merge_constraints_len_and_form() {
         // |A|>=5 and A=(3-7:abc) -> min should be 5, max should be 7, form = abc
-        let patterns = "A;|A|>=5;A=(3-7:abc)".parse::<Patterns>().unwrap();
+        let patterns = "A;|A|>=5;A=(3-7:abc)".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         assert_eq!(a.bounds.min_len, 5);
         assert_eq!(a.bounds.max_len_opt, Some(7));
@@ -780,7 +784,7 @@ mod tests {
     #[test]
     /// Check that !=ABC constraint gives correct `not_equal` sets for each variable.
     fn test_not_equal_constraint_three_vars() {
-        let patterns = "ABC;!=ABC".parse::<Patterns>().unwrap();
+        let patterns = "ABC;!=ABC".parse::<EquationContext>().unwrap();
         let a = patterns.var_constraints.get('A').unwrap();
         let b = patterns.var_constraints.get('B').unwrap();
         let c = patterns.var_constraints.get('C').unwrap();
@@ -794,7 +798,7 @@ mod tests {
     /// Test ordering tiebreakers: `constraint_score`.
     fn test_ordered_patterns_tiebreak_constraint_score() {
         // "Xz" has var + literal (score 3), "X" just var
-        let patterns = "Xz;X".parse::<Patterns>().unwrap();
+        let patterns = "Xz;X".parse::<EquationContext>().unwrap();
         assert_eq!(patterns.ordered_list.iter().map(|p| p.raw_string.clone()).collect::<Vec<_>>(), vec!["Xz", "X"]);
     }
 
@@ -802,14 +806,14 @@ mod tests {
     /// Test ordering tiebreakers: deterministic flag.
     fn test_ordered_patterns_tiebreak_deterministic() {
         // deterministic vs non-deterministic: "AB" (det) vs "A.B" (non-det)
-        let patterns = "A.B;AB".parse::<Patterns>().unwrap();
+        let patterns = "A.B;AB".parse::<EquationContext>().unwrap();
         assert_eq!(patterns.ordered_list.iter().map(|p| p.raw_string.clone()).collect::<Vec<_>>(), vec!["A.B", "AB"]);
     }
 
     #[test]
     /// Confirm that `IntoIterator` yields `ordered_list` without consuming `Patterns`.
     fn test_into_iterator_yields_ordered_list() {
-        let patterns = "AB;BC".parse::<Patterns>().unwrap();
+        let patterns = "AB;BC".parse::<EquationContext>().unwrap();
         let from_iter: Vec<_> = (&patterns).into_iter().map(|p| p.raw_string.clone()).collect();
         let ordered: Vec<_> = patterns.ordered_list.iter().map(|p| p.raw_string.clone()).collect();
         assert_eq!(from_iter, ordered);
@@ -818,7 +822,7 @@ mod tests {
     #[test]
     /// Verify that `build_order_maps` produces true inverses.
     fn test_build_order_maps_inverse() {
-        let patterns = "AB;BC;C".parse::<Patterns>().unwrap();
+        let patterns = "AB;BC;C".parse::<EquationContext>().unwrap();
         for (ordered_ix, &orig_ix) in patterns.ordered_to_original.iter().enumerate() {
             let roundtrip = patterns.original_to_ordered[orig_ix];
             assert_eq!(ordered_ix, roundtrip);
@@ -829,7 +833,7 @@ mod tests {
     /// Ensure conflicting complex constraints for the same variable produce an error.
     fn test_conflicting_complex_constraints_error() {
         assert!(matches!(
-            *"A=(1-5:k*);A=(5-6:a*);A".parse::<Patterns>().unwrap_err(),
+            *"A=(1-5:k*);A=(5-6:a*);A".parse::<EquationContext>().unwrap_err(),
             ParseError::ConflictingConstraint { var_char, older,  newer } if var_char == 'A' && older == "k*" && newer == "a*" )
         );
     }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -3,7 +3,7 @@ use crate::errors::{MaterializationError, ParseError};
 use crate::joint_constraints::{propagate_joint_to_var_bounds, JointConstraints};
 use crate::parser::prefilter::build_prefilter_regex;
 use crate::parser::{match_equation_all, ParsedForm};
-use crate::patterns::{Pattern, Patterns};
+use crate::patterns::{Pattern, EquationContext};
 use crate::scan_hints::{form_len_hints_pf, PatternLenHints};
 
 use crate::constraints::VarConstraints;
@@ -160,7 +160,7 @@ fn scan_batch(
     word_list: &[&str],
     start_idx: usize,
     batch_size: usize,
-    patterns: &Patterns,
+    patterns: &EquationContext,
     parsed_forms: &[ParsedForm],
     scan_hints: &[PatternLenHints],
     var_constraints: &VarConstraints,
@@ -388,7 +388,7 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
 
     // 1. Parse the input equation string into our `Patterns` struct.
     //    This holds each pattern string, its parsed form, and its `lookup_keys` (shared vars).
-    let patterns = input.parse::<Patterns>()?;
+    let patterns = input.parse::<EquationContext>()?;
 
     // 2. Build per-pattern lookup key specs (shared vars) for the join
     let lookup_keys: Vec<_> =

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -427,6 +427,7 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
 
     // 7. Get the joint constraints and use them to tighten per-variable constraints
     // This gets length bounds on variables (from the joint constraints)
+    // TODO: pull this from EquationContext
     let joint_constraints = JointConstraints::parse_equation(input);
 
     propagate_joint_to_var_bounds(&mut var_constraints, &joint_constraints);


### PR DESCRIPTION
* Rename `Patterns` to `EquationContext`
* parse JointConstraints within `EquationContext`
* refactor `set_var_constraints` to be much, much better

Note: now that we have joint constraints in the equation context, we should be able to remove step 7 from solve_equation. I did not include it in this PR because (a) it ain't broke and (b) no need to make the PR too much bigger than it already is